### PR TITLE
Activate classroom buttons

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_SOCKET_URL='http://localhost:4000'
-# NEXT_PUBLIC_SOCKET_URL='https://frempco.herokuapp.com/'
+NEXT_PUBLIC_SERVER_URL='http://localhost:4000'
+# NEXT_PUBLIC_SERVER_URL='https://frempco.herokuapp.com/'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.5.0",
         "@emotion/server": "^11.4.0",
         "@emotion/styled": "^11.3.0",
+        "@mui/icons-material": "^5.2.1",
         "@mui/material": "^5.0.6",
         "next": "^12.0.2",
         "prettier": "^2.4.1",
@@ -100,9 +101,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-      "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -466,15 +467,29 @@
         }
       }
     },
-    "node_modules/@mui/core/node_modules/@babel/runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
+    "node_modules/@mui/icons-material": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.2.1.tgz",
+      "integrity": "sha512-AFOn0bbaGd1dw8oYE40dv3I+QnfS5xP5HSUiUGsvb1ntP0cM1kW4VqQp7BtL7DbOpEsw1ZTbw67tDqSCH7utNg==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "@babel/runtime": "^7.16.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^17.0.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {
@@ -521,17 +536,6 @@
         }
       }
     },
-    "node_modules/@mui/material/node_modules/@babel/runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@mui/private-theming": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.0.1.tgz",
@@ -556,17 +560,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@mui/private-theming/node_modules/@babel/runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@mui/styled-engine": {
@@ -597,17 +590,6 @@
         "@emotion/styled": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@mui/styled-engine/node_modules/@babel/runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@mui/system": {
@@ -649,17 +631,6 @@
         }
       }
     },
-    "node_modules/@mui/system/node_modules/@babel/runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@mui/types": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.0.0.tgz",
@@ -689,17 +660,6 @@
       },
       "peerDependencies": {
         "react": "^17.0.2"
-      }
-    },
-    "node_modules/@mui/utils/node_modules/@babel/runtime": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-      "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@napi-rs/triples": {
@@ -5847,9 +5807,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-      "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -6127,16 +6087,14 @@
         "clsx": "^1.1.1",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
+      }
+    },
+    "@mui/icons-material": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.2.1.tgz",
+      "integrity": "sha512-AFOn0bbaGd1dw8oYE40dv3I+QnfS5xP5HSUiUGsvb1ntP0cM1kW4VqQp7BtL7DbOpEsw1ZTbw67tDqSCH7utNg==",
+      "requires": {
+        "@babel/runtime": "^7.16.3"
       }
     },
     "@mui/material": {
@@ -6156,16 +6114,6 @@
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2",
         "react-transition-group": "^4.4.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
       }
     },
     "@mui/private-theming": {
@@ -6176,16 +6124,6 @@
         "@babel/runtime": "^7.15.4",
         "@mui/utils": "^5.0.1",
         "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
       }
     },
     "@mui/styled-engine": {
@@ -6196,16 +6134,6 @@
         "@babel/runtime": "^7.15.4",
         "@emotion/cache": "^11.5.0",
         "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
       }
     },
     "@mui/system": {
@@ -6221,16 +6149,6 @@
         "clsx": "^1.1.1",
         "csstype": "^3.0.9",
         "prop-types": "^15.7.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
       }
     },
     "@mui/types": {
@@ -6249,16 +6167,6 @@
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        }
       }
     },
     "@napi-rs/triples": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.5.0",
     "@emotion/server": "^11.4.0",
     "@emotion/styled": "^11.3.0",
+    "@mui/icons-material": "^5.2.1",
     "@mui/material": "^5.0.6",
     "next": "^12.0.2",
     "prettier": "^2.4.1",

--- a/pages/teacher/classroom/[classroomName].tsx
+++ b/pages/teacher/classroom/[classroomName].tsx
@@ -1,6 +1,11 @@
 import Head from 'next/head';
 import { Typography } from '@mui/material';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
+import { Button } from '@mui/material';
+import {
+  PowerOff as PowerOffIcon,
+  Power as PowerIcon,
+} from '@mui/icons-material';
 
 import { getAllClassroomNames } from '@utils/classrooms';
 import Layout from '@components/Layout';
@@ -24,7 +29,25 @@ export async function getStaticProps({ params }) {
 }
 
 export default function TeacherDashboard({ classroomName }) {
+  const apiUrl = `${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1`;
   const socket = useContext(SocketContext);
+  const [isActiveClassroom, setIsActiveClassroom] = useState(false);
+
+  async function activateClassroom() {
+    const postResponse = await fetch(`${apiUrl}/classrooms/${classroomName}`, {
+      method: 'POST',
+    });
+    const { isActive } = await postResponse.json();
+    setIsActiveClassroom(isActive);
+  }
+
+  async function deactivateClassroom() {
+    const postResponse = await fetch(`${apiUrl}/classrooms/${classroomName}`, {
+      method: 'DELETE',
+    });
+    const { isActive } = await postResponse.json();
+    setIsActiveClassroom(isActive);
+  }
 
   return (
     <Layout>
@@ -34,13 +57,32 @@ export default function TeacherDashboard({ classroomName }) {
       </Head>
 
       <main>
-        <Typography
-          variant='h3'
-          sx={{ color: (theme) => theme.palette.common.white }}
-        >
-          Hello teacher! Welcome to your dashboard for your classroom named{' '}
-          {classroomName}! Your socket ID is {socket?.id ?? 'NO SOCKET FOUND'}
+        <Typography variant='h4' sx={{ color: 'white' }}>
+          Hello teacher! Welcome to your classroom: {classroomName}
         </Typography>
+        <Typography variant='h4' sx={{ color: 'white' }}>
+          Your socket ID is {socket?.id ?? 'NO SOCKET FOUND'}
+        </Typography>
+        {isActiveClassroom ? (
+          <Button
+            variant='contained'
+            size='large'
+            color='warning'
+            startIcon={<PowerOffIcon />}
+            onClick={deactivateClassroom}
+          >
+            Deactivate classroom
+          </Button>
+        ) : (
+          <Button
+            variant='contained'
+            size='large'
+            startIcon={<PowerIcon />}
+            onClick={activateClassroom}
+          >
+            Activate classroom
+          </Button>
+        )}
       </main>
     </Layout>
   );

--- a/src/contexts/SocketContext.tsx
+++ b/src/contexts/SocketContext.tsx
@@ -5,8 +5,8 @@ interface ProviderProps {
   children: React.ReactNode;
 }
 
-const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL;
-const socket = io(SOCKET_URL);
+const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL;
+const socket = io(SERVER_URL);
 
 const SocketContext = createContext(socket);
 


### PR DESCRIPTION
Closes #14 

- Added buttons to teacher admin page to activate or deactivate a classroom
- Installed npm package `@mui/icons-material`
- Refactored by renaming SOCKET_URL variable to SERVER_URL

Test plan:
- Ran backend branch containing [backend PR for classroom activation routes](https://github.com/mssiegel/frempco-server/pull/3)
- After visiting the teacher's page, I could click the buttons to either activate or deactivate the classroom

https://user-images.githubusercontent.com/29524485/145339493-555da51c-83ed-4b73-acbd-1a957b3c5f49.mp4

 