### PR TITLE
Added Navbar with Home link

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,5 @@
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
+import Link from '@utilComponents/Link';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -6,6 +7,19 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <Box sx={{ background: '#87002a', minHeight: '100vh' }}>{children}</Box>
+    <Box sx={{ background: '#87002a', minHeight: '100vh', pl: 2 }}>
+      <Navbar />
+      {children}
+    </Box>
+  );
+}
+
+function Navbar() {
+  return (
+    <Typography variant='h4' sx={{ ml: 10, pt: 1, pb: 2 }}>
+      <Link href='/' underline='hover' color='white'>
+        Home
+      </Link>
+    </Typography>
   );
 }


### PR DESCRIPTION
Closes #24 

- Added a simple navbar with a link to return to the homepage

Test plan:
- Hovering over the HOME link will underline it.
- Clicking it will return to homepage.
![image](https://user-images.githubusercontent.com/29524485/145721586-e6d464ea-59aa-476f-b43d-ba6ba9429dcc.png)

![image](https://user-images.githubusercontent.com/29524485/145721594-d7937e4c-9c6f-48b0-8a5b-9c6dfd7949e7.png)

