### PR TITLE
Student can enter classroom

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,14 +8,11 @@ import { useRouter } from 'next/router';
 
 import Link from '@utilComponents/Link';
 import Layout from '@components/Layout';
-import classrooms from 'data/classrooms.json';
-import { getClassroom } from '@utils/classrooms';
+import { getClassroom, sampleClassroomName } from '@utils/classrooms';
 
 export default function Home() {
   const router = useRouter();
   const apiUrl = `${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1`;
-
-  const sampleClassroomName = classrooms[0].classroomName;
 
   async function visitStudentsPage() {
     const classroom = window.prompt('What classroom are you visiting?');

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router';
 import Link from '@utilComponents/Link';
 import Layout from '@components/Layout';
 import classrooms from 'data/classrooms.json';
+import { getClassroom } from '@utils/classrooms';
 
 export default function Home() {
   const router = useRouter();
@@ -46,10 +47,6 @@ export default function Home() {
 
     // Visit teachers page
     router.push(`/teacher/classroom/${classroom}`);
-  }
-
-  function getClassroom(classroom) {
-    return classrooms.find(({ classroomName }) => classroomName === classroom);
   }
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,56 @@
-import { Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
+import {
+  School as SchoolIcon,
+  Lightbulb as LightbulbIcon,
+} from '@mui/icons-material';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 
 import Link from '@utilComponents/Link';
 import Layout from '@components/Layout';
 import classrooms from 'data/classrooms.json';
 
 export default function Home() {
+  const router = useRouter();
+  const apiUrl = `${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1`;
+
   const sampleClassroomName = classrooms[0].classroomName;
+
+  async function visitStudentsPage() {
+    const classroom = window.prompt('What classroom are you visiting?');
+    const classroomObj = getClassroom(classroom);
+    if (!classroomObj) return window.alert(`Invalid classroom: ${classroom}`);
+
+    const getResponse = await fetch(`${apiUrl}/classrooms/${classroom}`);
+    const { isActive } = await getResponse.json();
+    if (!isActive)
+      return window.alert(
+        `Classroom not activated: ${classroom}\n Please wait for your teacher to activate your classroom and try again.`,
+      );
+
+    const studentName = window.prompt('Classroom found! What is your name?');
+    // TODO: send socket request to notify the teacher
+
+    // Visit students page
+    router.push(`/student/classroom/${classroom}`);
+  }
+
+  function visitTeachersPage() {
+    const classroom = window.prompt('What classroom are you visiting?');
+    const classroomObj = getClassroom(classroom);
+    if (!classroomObj) return window.alert(`Invalid classroom: ${classroom}`);
+
+    const password = window.prompt(`What is the password for ${classroom}?`);
+    if (String(classroomObj.password) !== password)
+      return window.alert(`IncorrectPassword: ${password}`);
+
+    // Visit teachers page
+    router.push(`/teacher/classroom/${classroom}`);
+  }
+
+  function getClassroom(classroom) {
+    return classrooms.find(({ classroomName }) => classroomName === classroom);
+  }
 
   return (
     <Layout>
@@ -26,16 +70,46 @@ export default function Home() {
         >
           Welcome to Frempco!
         </Typography>
-        <Typography variant='h3' sx={{ m: 5 }}>
-          <Link href={`/teacher/classroom/${sampleClassroomName}`}>
-            Visit Teachers admin page
-          </Link>
-        </Typography>
-        <Typography variant='h3' sx={{ m: 5 }}>
-          <Link href={`/student/classroom/${sampleClassroomName}`}>
-            Visit Students classroom page
-          </Link>
-        </Typography>
+        <Box sx={{ m: 5 }}>
+          <Typography variant='h3' sx={{ color: 'white', mb: 1 }}>
+            For Students:
+          </Typography>
+          <Button
+            variant='contained'
+            size='large'
+            startIcon={<LightbulbIcon />}
+            onClick={visitStudentsPage}
+          >
+            Students page
+          </Button>
+
+          <Typography variant='h3' sx={{ color: 'white', mb: 1, mt: 8 }}>
+            For Teachers:
+          </Typography>
+          <Button
+            variant='contained'
+            size='large'
+            startIcon={<SchoolIcon />}
+            onClick={visitTeachersPage}
+          >
+            Teachers page
+          </Button>
+
+          <Typography variant='h5' sx={{ m: 5, mt: 10, color: 'gray' }}>
+            Below link shortcuts are for development purposes only and will be
+            deleted prior to making this website live and ready for teachers
+          </Typography>
+          <Typography variant='h5' sx={{ m: 5 }}>
+            <Link href={`/teacher/classroom/${sampleClassroomName}`}>
+              Visit Teachers admin page
+            </Link>
+          </Typography>
+          <Typography variant='h5' sx={{ m: 5 }}>
+            <Link href={`/student/classroom/${sampleClassroomName}`}>
+              Visit Students classroom page
+            </Link>
+          </Typography>
+        </Box>
       </main>
     </Layout>
   );

--- a/src/utils/classrooms.tsx
+++ b/src/utils/classrooms.tsx
@@ -11,3 +11,5 @@ export function getAllClassroomNames() {
 export function getClassroom(classroom: string) {
   return classrooms.find(({ classroomName }) => classroomName === classroom);
 }
+
+export const sampleClassroomName = classrooms[0].classroomName;

--- a/src/utils/classrooms.tsx
+++ b/src/utils/classrooms.tsx
@@ -7,3 +7,7 @@ export function getAllClassroomNames() {
     },
   }));
 }
+
+export function getClassroom(classroom: string) {
+  return classrooms.find(({ classroomName }) => classroomName === classroom);
+}


### PR DESCRIPTION
Closes #16

Adds the process for students to enter their classroom. It uses `window.prompt()` for the sake of faster engineering time. The `window.prompt()` and `window.alert()` will need to be replaced by better visuals later.

- A teacher can enter the teachers page via the homepage by typing in their classroom name and password. 
- A student can enter the students page via the homepage by typing in their classroom name. If their classroom is activated, they will visit their page, otherwise they'll receive an alert message. 

TODO in a future issue/diff: when a student enters the classroom, a socket request should be sent to notify the teacher.

Test plan: 
- I received an alert when entering an invalid classroom name, both for teachers page and for students page. 
- I received an alert when entering an invalid password for the teachers page.
- I tried visiting a non-activated classroom as a student and was blocked. I then entered the teachers page and activated the classroom. I could then enter the classroom as a student. 

![image](https://user-images.githubusercontent.com/29524485/145745859-d517bde5-f881-4f7f-bd1b-23856ab36d74.png)
