### PR TITLE
Minimized development bundles for Material UI imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,24 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [
+    // "babel-plugin-import" minimizes development bundles for Material UI projects. See: https://mui.com/guides/minimizing-bundle-size/
+    [
+      "babel-plugin-import",
+      {
+        "libraryName": "@mui/material",
+        "libraryDirectory": "",
+        "camel2DashComponentName": false
+      },
+      "core"
+    ],
+    [
+      "babel-plugin-import",
+      {
+        "libraryName": "@mui/icons-material",
+        "libraryDirectory": "",
+        "camel2DashComponentName": false
+      },
+      "icons"
+    ]
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@types/react": "^17.0.34",
+        "babel-plugin-import": "^1.13.3",
         "eslint": "8.1.0",
         "eslint-config-next": "11.1.2",
         "typescript": "^4.4.4"
@@ -1489,6 +1490,16 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
+    },
+    "node_modules/babel-plugin-import": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import/-/babel-plugin-import-1.13.3.tgz",
+      "integrity": "sha512-1qCWdljJOrDRH/ybaCZuDgySii4yYrtQ8OJQwrcDqdt0y67N30ng3X3nABg6j7gR7qUJgcMa9OMhc4AGViDwWw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/runtime": "^7.0.0"
+      }
     },
     "node_modules/babel-plugin-macros": {
       "version": "2.8.0",
@@ -6718,6 +6729,16 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
+    },
+    "babel-plugin-import": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import/-/babel-plugin-import-1.13.3.tgz",
+      "integrity": "sha512-1qCWdljJOrDRH/ybaCZuDgySii4yYrtQ8OJQwrcDqdt0y67N30ng3X3nABg6j7gR7qUJgcMa9OMhc4AGViDwWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/runtime": "^7.0.0"
+      }
     },
     "babel-plugin-macros": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@types/react": "^17.0.34",
+    "babel-plugin-import": "^1.13.3",
     "eslint": "8.1.0",
     "eslint-config-next": "11.1.2",
     "typescript": "^4.4.4"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Head from 'next/head';
 import { AppProps } from 'next/app';
 import { ThemeProvider } from '@mui/material/styles';
-import CssBaseline from '@mui/material/CssBaseline';
+import { CssBaseline } from '@mui/material';
 import { CacheProvider, EmotionCache } from '@emotion/react';
 
 import theme from '@theme/muiTheme';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,8 @@
 import { Box, Button, Typography } from '@mui/material';
-import SchoolIcon from '@mui/icons-material/School';
-import LightbulbIcon from '@mui/icons-material/Lightbulb';
+import {
+  School as SchoolIcon,
+  Lightbulb as LightbulbIcon,
+} from '@mui/icons-material';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 

--- a/pages/teacher/classroom/[classroomName].tsx
+++ b/pages/teacher/classroom/[classroomName].tsx
@@ -1,9 +1,10 @@
 import Head from 'next/head';
-import { Typography } from '@mui/material';
 import { useContext, useState } from 'react';
-import { Button } from '@mui/material';
-import PowerIcon from '@mui/icons-material/Power';
-import PowerOffIcon from '@mui/icons-material/PowerOff';
+import { Button, Typography } from '@mui/material';
+import {
+  Power as PowerIcon,
+  PowerOff as PowerOffIcon,
+} from '@mui/icons-material';
 
 import { getAllClassroomNames } from '@utils/classrooms';
 import Layout from '@components/Layout';

--- a/src/theme/muiTheme.ts
+++ b/src/theme/muiTheme.ts
@@ -1,4 +1,4 @@
-import { createTheme } from '@mui/material';
+import { createTheme } from '@mui/material/styles';
 
 /**
  * This is the default MUI theme used in the app


### PR DESCRIPTION
Minimized development bundle size by following directions in https://mui.com/guides/minimizing-bundle-size/

Text plan:
- app works correctly and moving between pages on development mode is now much faster!