### PR TITLE
Displays static chatbox on teacher's page

### DIFF
--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -2,21 +2,11 @@
 
 import { Box, Typography } from '@mui/material';
 import { useEffect } from 'react';
-import Filter from 'bad-words';
 
 import conversationCSS from './Conversation.css';
+import { filterWords } from '@utils/classrooms';
 
 export default function Conversation({ socket, chat, setChat, scrollDown }) {
-  function filterWords(words) {
-    const filter = new Filter();
-    try {
-      return filter.clean(words);
-      // the filter throws an error if the string only has non-letter characters
-    } catch (e) {
-      return words;
-    }
-  }
-
   useEffect(() => {
     if (socket) {
       socket.on('chat message', ({ character, message }) => {
@@ -40,7 +30,7 @@ export default function Conversation({ socket, chat, setChat, scrollDown }) {
           <span>
             Hi <span css={conversationCSS.you}>{chat.initialChar}</span>
           </span>
-          <span>{chat.startTime || '3:05pm'}</span>
+          <span>{chat.startTime}</span>
         </Box>
         <span>You matched with </span>
         <span css={conversationCSS.peer}>{chat.peer}</span>

--- a/src/components/pages/StudentsPage/index.tsx
+++ b/src/components/pages/StudentsPage/index.tsx
@@ -1,16 +1,9 @@
 import { Box, Typography } from '@mui/material';
 import { useContext, useEffect, useState } from 'react';
 
-import { ClassroomProps } from '@utils/classrooms';
+import { ClassroomProps, currentTime } from '@utils/classrooms';
 import { SocketContext } from '@contexts/SocketContext';
 import Chatbox from './Chatbox';
-
-function currentTime() {
-  return new Date().toLocaleString('en-US', {
-    hour: 'numeric',
-    minute: 'numeric',
-  });
-}
 
 export default function StudentsPage({ classroomName }: ClassroomProps) {
   const socket = useContext(SocketContext);
@@ -31,13 +24,13 @@ export default function StudentsPage({ classroomName }: ClassroomProps) {
   useEffect(() => {
     if (socket) {
       socket.on('chat start', ({ yourCharacter, peersCharacter }) => {
-        setChat((chat) => ({
-          ...chat,
+        setChat({
           you: yourCharacter,
           peer: peersCharacter,
           initialChar: yourCharacter,
+          conversation: [],
           startTime: currentTime(),
-        }));
+        });
         setChatInSession(true);
       });
     }

--- a/src/components/pages/TeachersPage/Chatbox.css.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.css.tsx
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+
+const chatboxContainer = css`
+  width: 98%;
+  max-width: 500px;
+`;
+
+const chatboxTop = css`
+  background: #f8e5e0;
+  border-radius: 10px 10px 10px 10px;
+  min-height: 260px;
+  padding: 10px;
+`;
+
+const chatboxCSS = {
+  chatboxContainer,
+  chatboxTop,
+};
+
+export default chatboxCSS;

--- a/src/components/pages/TeachersPage/Chatbox.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.tsx
@@ -1,0 +1,16 @@
+/** @jsxImportSource @emotion/react */
+
+import { Box } from '@mui/material';
+
+import chatboxCSS from './Chatbox.css';
+import Conversation from './Conversation';
+
+export default function Chatbox({ chat }) {
+  return (
+    <Box css={chatboxCSS.chatboxContainer}>
+      <Box css={chatboxCSS.chatboxTop}>
+        <Conversation chat={chat} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/pages/TeachersPage/Conversation.css.tsx
+++ b/src/components/pages/TeachersPage/Conversation.css.tsx
@@ -3,23 +3,23 @@ import { css } from '@emotion/react';
 const introText = css`
   font-style: italic;
   color: gray;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
 `;
 
-const you = css`
+const student1 = css`
   font-weight: bold;
   color: #0070ff;
 `;
 
-const peer = css`
+const student2 = css`
   font-weight: bold;
   color: red;
 `;
 
 const conversationCSS = {
   introText,
-  peer,
-  you,
+  student1,
+  student2,
 };
 
 export default conversationCSS;

--- a/src/components/pages/TeachersPage/Conversation.tsx
+++ b/src/components/pages/TeachersPage/Conversation.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource @emotion/react */
+
+import { Box, Typography } from '@mui/material';
+
+import conversationCSS from './Conversation.css';
+import { filterWords } from '@utils/classrooms';
+
+export default function Conversation({ chat }) {
+  const [student1, student2] = chat.studentPair;
+
+  return (
+    <Box>
+      <Box css={conversationCSS.introText}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Box>
+            <span css={conversationCSS.student1}>{student1.realName}</span> (
+            {student1.character})
+            <br />
+            <span css={conversationCSS.student2}>{student2.realName}</span> (
+            {student2.character})
+          </Box>
+          <span>{chat.startTime}</span>
+        </Box>
+        ------
+      </Box>
+      {chat.conversation.map(([person, character, message], i) => {
+        let fontCSS = {};
+        if (person === 'student1') fontCSS = conversationCSS.student1;
+        else if (person === 'student2') fontCSS = conversationCSS.student2;
+
+        return (
+          <Typography key={i}>
+            <span css={fontCSS}>{filterWords(character)}: </span>
+            <span>{filterWords(message)}</span>
+          </Typography>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/components/pages/TeachersPage/index.tsx
+++ b/src/components/pages/TeachersPage/index.tsx
@@ -9,16 +9,21 @@ import {
   Typography,
 } from '@mui/material';
 
-import { ClassroomProps, Student } from '@utils/classrooms';
+import { ClassroomProps, Student, currentTime } from '@utils/classrooms';
 import { SocketContext } from '@contexts/SocketContext';
+import Chatbox from './Chatbox';
 import UnpairedStudentsList from './UnpairedStudentsList';
 import ActivateButton from './ActivateButton';
 
 type StudentPair = [Student, Student];
 
+type ChatMessage = ['student1' | 'student2', string, string];
+
 interface StudentChat {
   chatId: string;
   studentPair: StudentPair;
+  conversation: ChatMessage[];
+  startTime: string;
 }
 
 export default function TeachersPage({ classroomName }: ClassroomProps) {
@@ -33,13 +38,21 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
     //     { socketId: 'as343da11sf', realName: 'Sam', character: 'pirate' },
     //     { socketId: 'as31afdsf', realName: 'Rachel', character: 'dentist' },
     //   ],
+    //   conversation: [
+    //     ['student1', 'vampire', 'i need blood'],
+    //     ['student2', 'wizard', 'i will cast a spell to make some'],
+    //   ],
+    //   startTime: '',
     // },
   ]);
 
   useEffect(() => {
     if (socket) {
       socket.on('chat started - two students', ({ chatId, studentPair }) => {
-        setStudentChats((chats) => [...chats, { chatId, studentPair }]);
+        setStudentChats((chats) => [
+          ...chats,
+          { chatId, studentPair, conversation: [], startTime: currentTime() },
+        ]);
       });
     }
 
@@ -49,22 +62,10 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
   });
 
   function showDisplayedChat() {
-    console.log('display chat clicked');
     const chat = studentChats.find((chat) => chat.chatId === displayedChat);
     if (!chat) return null;
 
-    const [student1, student2] = chat.studentPair;
-
-    // TODO NEXT: Turn this into a real chatbox!!
-    return (
-      <div>
-        <p style={{ color: 'white' }}>
-          Student 1: {student1.realName} ({student1.character})
-          <br />
-          Student 2: {student2.realName} ({student2.character})
-        </p>
-      </div>
-    );
+    return <Chatbox chat={chat} />;
   }
 
   return (
@@ -81,10 +82,7 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
         </Grid>
 
         <Grid item xs={12} md={7}>
-          <Typography variant='h4'>
-            Displayed student chatbox will go here!
-            {showDisplayedChat()}
-          </Typography>
+          {showDisplayedChat()}
         </Grid>
       </Grid>
 

--- a/src/utils/classrooms.tsx
+++ b/src/utils/classrooms.tsx
@@ -1,3 +1,5 @@
+import Filter from 'bad-words';
+
 import classrooms from 'data/classrooms.json';
 
 export function getAllClassroomNames() {
@@ -20,6 +22,23 @@ export function swap<T>(arr: Array<T>, i1: number, i2: number) {
   const temp = arr[i2];
   arr[i2] = arr[i1];
   arr[i1] = temp;
+}
+
+export function currentTime() {
+  return new Date().toLocaleString('en-US', {
+    hour: 'numeric',
+    minute: 'numeric',
+  });
+}
+
+export function filterWords(words) {
+  const filter = new Filter();
+  try {
+    return filter.clean(words);
+    // the filter throws an error if the string only has non-letter characters
+  } catch (e) {
+    return words;
+  }
 }
 
 export const sampleClassroomName = classrooms[0].classroomName;


### PR DESCRIPTION
Addresses some of #38 

- When teacher clicks "display chat", a static version of those student's conversation appears
- The displayed chatbox contains the names of which students are chatting
- Most of the chatbox code and styles were copied from the Students page chatbox
- Extracted helper functions from both chatboxes to `/utils/classrooms.tsx`

Test plan:
- I joined as 4 separate students. I paired them up on Teachers page and was able to click "Display chat" to see the static versions of the chatboxes.  [See screenshot below]

TODO NEXT: Add socket listeners so the student's messages are saved in state to the teacher's page. Saving them to state will let the new messages appear in the displayed chatbox on the teachers page.

![image](https://user-images.githubusercontent.com/29524485/151727175-4c4b1696-2c3b-4699-92c5-fa9ea5550b0a.png)