### PR TITLE
Teachers Page listens to students chat messages

### DIFF
--- a/src/components/pages/StudentsPage/index.tsx
+++ b/src/components/pages/StudentsPage/index.tsx
@@ -7,7 +7,7 @@ import Chatbox from './Chatbox';
 
 export default function StudentsPage({ classroomName }: ClassroomProps) {
   const socket = useContext(SocketContext);
-  console.log('socketId:', socket?.id ?? 'No socket found');
+  console.log('Student socketId:', socket?.id ?? 'No socket found');
 
   const [chatInSession, setChatInSession] = useState(false);
   const [chat, setChat] = useState({

--- a/src/components/pages/TeachersPage/index.tsx
+++ b/src/components/pages/TeachersPage/index.tsx
@@ -28,7 +28,7 @@ interface StudentChat {
 
 export default function TeachersPage({ classroomName }: ClassroomProps) {
   const socket = useContext(SocketContext);
-  console.log('socketId:', socket?.id ?? 'No socket found');
+  console.log('Teacher socketId:', socket?.id ?? 'No socket found');
 
   const [displayedChat, setDisplayedChat] = useState('');
   const [studentChats, setStudentChats] = useState<StudentChat[]>([
@@ -54,10 +54,28 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
           { chatId, studentPair, conversation: [], startTime: currentTime() },
         ]);
       });
+
+      socket.on(
+        'student chat message',
+        ({ character, message, socketId, chatId }) => {
+          const chats = [...studentChats];
+          const chat = chats.find((chat) => chat.chatId === chatId);
+          const student =
+            chat.studentPair[0].socketId === socketId ? 'student1' : 'student2';
+          chat.conversation = [
+            ...chat.conversation,
+            [student, character, message],
+          ];
+          setStudentChats(chats);
+        },
+      );
     }
 
     return () => {
-      if (socket) socket.off('chat started - two students');
+      if (socket) {
+        socket.off('chat started - two students');
+        socket.off('student chat message');
+      }
     };
   });
 


### PR DESCRIPTION
Closes #38

- Teachers Page listens to chat messages between students in real-time
- When teacher clicks "display chat", the entire chat between the two students is displayed

Test plan:
- I ran the [backend PR locally](https://github.com/mssiegel/frempco-server/pull/5). I joined as 4 separate students. I paired them up on Teachers page. I chatted between the two student pairs.  The student chat messages were appearing on the Teacher's displayed chatbox in real-time. [See Screenshot]

TODO NEXT: The Teacher's viewport should automatically down when new messages are received in the Teacher's displayed chat.

![image](https://user-images.githubusercontent.com/29524485/151894083-baf60a91-1b97-4ac3-912b-1b05a3a37970.png)