### PR TITLE
Fixes the Grid / Scrolling Issue #42

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Head from 'next/head';
+import './styles.css';
 import { AppProps } from 'next/app';
 import { ThemeProvider } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material';

--- a/pages/styles.css
+++ b/pages/styles.css
@@ -1,0 +1,18 @@
+/* Consistent Scrollbars for all browsers and 
+platforms (Makes windows scrollbars prettier) */
+
+/* width */
+::-webkit-scrollbar {
+  width: 15px;
+}
+
+/* Handle */
+::-webkit-scrollbar-thumb {
+  background: rgba(128, 128, 128, 0.175);
+  border-radius: 10px;
+}
+
+/* Handle on hover */
+::-webkit-scrollbar-thumb:hover {
+  background: gray;
+}

--- a/src/components/pages/StudentsPage/Chatbox.css.tsx
+++ b/src/components/pages/StudentsPage/Chatbox.css.tsx
@@ -10,6 +10,8 @@ const chatboxTop = css`
   border-radius: 10px 10px 0 0;
   min-height: 260px;
   padding: 10px 10px 0 10px;
+  max-height: 260px;
+  overflow-y: overlay;
 `;
 
 const chatboxBottom = css`

--- a/src/components/pages/StudentsPage/Chatbox.tsx
+++ b/src/components/pages/StudentsPage/Chatbox.tsx
@@ -8,11 +8,11 @@ import Conversation from './Conversation';
 import SendMessages from './SendMessages';
 
 export default function Chatbox({ socket, chat, setChat }) {
-  const messageInput = useRef(null);
+  const lastMessage = useRef(null);
 
   function scrollDown() {
-    if (messageInput.current)
-      messageInput.current.scrollIntoView({ behavior: 'smooth' });
+    if (lastMessage.current)
+      lastMessage.current.scrollIntoView({ behavior: 'smooth' });
   }
 
   return (
@@ -23,6 +23,7 @@ export default function Chatbox({ socket, chat, setChat }) {
           chat={chat}
           setChat={setChat}
           scrollDown={scrollDown}
+          lastMessage={lastMessage}
         />
       </Box>
       <Box css={chatboxCSS.chatboxBottom}>
@@ -31,7 +32,6 @@ export default function Chatbox({ socket, chat, setChat }) {
           chat={chat}
           setChat={setChat}
           scrollDown={scrollDown}
-          messageInput={messageInput}
         />
       </Box>
     </Box>

--- a/src/components/pages/StudentsPage/Chatbox.tsx
+++ b/src/components/pages/StudentsPage/Chatbox.tsx
@@ -8,31 +8,13 @@ import Conversation from './Conversation';
 import SendMessages from './SendMessages';
 
 export default function Chatbox({ socket, chat, setChat }) {
-  const lastMessage = useRef(null);
-
-  function scrollDown() {
-    if (lastMessage.current)
-      lastMessage.current.scrollIntoView({ behavior: 'smooth' });
-  }
-
   return (
     <Box css={chatboxCSS.chatboxContainer}>
       <Box css={chatboxCSS.chatboxTop}>
-        <Conversation
-          socket={socket}
-          chat={chat}
-          setChat={setChat}
-          scrollDown={scrollDown}
-          lastMessage={lastMessage}
-        />
+        <Conversation socket={socket} chat={chat} setChat={setChat} />
       </Box>
       <Box css={chatboxCSS.chatboxBottom}>
-        <SendMessages
-          socket={socket}
-          chat={chat}
-          setChat={setChat}
-          scrollDown={scrollDown}
-        />
+        <SendMessages socket={socket} chat={chat} setChat={setChat} />
       </Box>
     </Box>
   );

--- a/src/components/pages/StudentsPage/Conversation.css.tsx
+++ b/src/components/pages/StudentsPage/Conversation.css.tsx
@@ -16,10 +16,15 @@ const peer = css`
   color: red;
 `;
 
+const msg = css`
+  word-break: break-word;
+`;
+
 const conversationCSS = {
   introText,
   peer,
   you,
+  msg,
 };
 
 export default conversationCSS;

--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -31,7 +31,7 @@ export default function Conversation({
 
   useEffect(() => {
     scrollDown();
-  }, [chat.conversation, peerIsTyping]);
+  }, [chat.conversation]);
 
   return (
     <Box>

--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -20,7 +20,6 @@ export default function Conversation({
           ...chat,
           conversation: [...chat.conversation, ['peer', character, message]],
         }));
-        scrollDown();
       });
     }
 
@@ -49,14 +48,15 @@ export default function Conversation({
         let fontCSS = {};
         if (person === 'peer') fontCSS = conversationCSS.peer;
         else if (person === 'you') fontCSS = conversationCSS.you;
-
         return (
           <Typography key={i}>
             <span css={fontCSS}>{filterWords(character)}: </span>
-            <span>{filterWords(message)}</span>
+            <span css={conversationCSS.msg}>{filterWords(message)}</span>
           </Typography>
         );
       })}
+
+      <span ref={lastMessage} />
     </Box>
   );
 }

--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -6,7 +6,13 @@ import { useEffect } from 'react';
 import conversationCSS from './Conversation.css';
 import { filterWords } from '@utils/classrooms';
 
-export default function Conversation({ socket, chat, setChat, scrollDown }) {
+export default function Conversation({
+  socket,
+  chat,
+  setChat,
+  scrollDown,
+  lastMessage,
+}) {
   useEffect(() => {
     if (socket) {
       socket.on('chat message', ({ character, message }) => {

--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -23,6 +23,10 @@ export default function Conversation({ socket, chat, setChat, scrollDown }) {
     };
   }, []);
 
+  useEffect(() => {
+    scrollDown();
+  }, [chat.conversation, peerIsTyping]);
+
   return (
     <Box>
       <Box css={conversationCSS.introText}>

--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -1,18 +1,14 @@
 /** @jsxImportSource @emotion/react */
 
 import { Box, Typography } from '@mui/material';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import conversationCSS from './Conversation.css';
 import { filterWords } from '@utils/classrooms';
+import { scrollDown } from '@utils/classrooms';
 
-export default function Conversation({
-  socket,
-  chat,
-  setChat,
-  scrollDown,
-  lastMessage,
-}) {
+export default function Conversation({ socket, chat, setChat }) {
+  const lastMessage = useRef(null);
   useEffect(() => {
     if (socket) {
       socket.on('chat message', ({ character, message }) => {
@@ -29,7 +25,7 @@ export default function Conversation({
   }, []);
 
   useEffect(() => {
-    scrollDown();
+    scrollDown(lastMessage);
   }, [chat.conversation]);
 
   return (

--- a/src/components/pages/StudentsPage/SendMessages.css.tsx
+++ b/src/components/pages/StudentsPage/SendMessages.css.tsx
@@ -31,6 +31,15 @@ const message = css`
   }
 `;
 
-const sendMessagesCSS = { characterName, message };
+const peerIsTyping = css`
+  padding: 5px 10px;
+  margin-bottom: 0;
+  text-align: left;
+  font-size: 16px;
+  color: #aaa;
+  font-style: italic;
+`;
+
+const sendMessagesCSS = { characterName, message, peerIsTyping };
 
 export default sendMessagesCSS;

--- a/src/components/pages/StudentsPage/SendMessages.tsx
+++ b/src/components/pages/StudentsPage/SendMessages.tsx
@@ -35,6 +35,10 @@ export default function SendMessages({
     messageInput.current.focus();
   }
 
+  useEffect(() => {
+    scrollDown();
+  }, [chat.conversation]);
+
   return (
     <Box>
       <form onSubmit={sendMessage}>

--- a/src/components/pages/StudentsPage/SendMessages.tsx
+++ b/src/components/pages/StudentsPage/SendMessages.tsx
@@ -7,7 +7,7 @@ import { filterWords } from '@utils/classrooms';
 import sendMessagesCSS from './SendMessages.css';
 
 let peerTypingTimer = null;
-export default function SendMessages({ socket, chat, setChat, scrollDown }) {
+export default function SendMessages({ socket, chat, setChat }) {
   const [message, setMessage] = useState('');
   const [peerIsTyping, setPeerIsTyping] = useState(false);
   const [peerName, setPeerName] = useState('');
@@ -59,10 +59,6 @@ export default function SendMessages({ socket, chat, setChat, scrollDown }) {
       message,
     });
   }
-
-  useEffect(() => {
-    scrollDown();
-  }, [chat.conversation]);
 
   return (
     <Box>

--- a/src/components/pages/StudentsPage/SendMessages.tsx
+++ b/src/components/pages/StudentsPage/SendMessages.tsx
@@ -2,7 +2,7 @@
 
 import { Box, Fab } from '@mui/material';
 import { Send as SendIcon } from '@mui/icons-material';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import sendMessagesCSS from './SendMessages.css';
 

--- a/src/components/pages/StudentsPage/SendMessages.tsx
+++ b/src/components/pages/StudentsPage/SendMessages.tsx
@@ -6,13 +6,7 @@ import { useState, useEffect } from 'react';
 
 import sendMessagesCSS from './SendMessages.css';
 
-export default function SendMessages({
-  socket,
-  chat,
-  setChat,
-  scrollDown,
-  messageInput,
-}) {
+export default function SendMessages({ socket, chat, setChat, scrollDown }) {
   const [message, setMessage] = useState('');
 
   function sendMessage(e) {
@@ -24,7 +18,7 @@ export default function SendMessages({
         conversation: [...chat.conversation, ['you', chat.you, message]],
       }));
       setMessage('');
-      scrollDown();
+
       if (socket) {
         socket.emit('chat message', {
           character: chat.you,
@@ -32,7 +26,7 @@ export default function SendMessages({
         });
       }
     }
-    messageInput.current.focus();
+
   }
 
   useEffect(() => {
@@ -56,7 +50,6 @@ export default function SendMessages({
           placeholder='Say something'
           maxLength={75}
           onChange={(e) => setMessage(e.target.value)}
-          ref={messageInput}
           autoFocus
         />
 

--- a/src/components/pages/TeachersPage/Chatbox.css.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.css.tsx
@@ -10,6 +10,8 @@ const chatboxTop = css`
   border-radius: 10px 10px 10px 10px;
   min-height: 260px;
   padding: 10px;
+  max-height: 260px;
+  overflow-y: overlay;
 `;
 
 const chatboxCSS = {

--- a/src/components/pages/TeachersPage/Conversation.css.tsx
+++ b/src/components/pages/TeachersPage/Conversation.css.tsx
@@ -16,10 +16,15 @@ const student2 = css`
   color: red;
 `;
 
+const msg = css`
+  word-break: break-word;
+`;
+
 const conversationCSS = {
   introText,
   student1,
   student2,
+  msg,
 };
 
 export default conversationCSS;

--- a/src/components/pages/TeachersPage/Conversation.tsx
+++ b/src/components/pages/TeachersPage/Conversation.tsx
@@ -38,7 +38,7 @@ export default function Conversation({ chat }) {
         return (
           <Typography key={i}>
             <span css={fontCSS}>{filterWords(character)}: </span>
-            <span>{filterWords(message)}</span>
+            <span css={conversationCSS.msg}>{filterWords(message)}</span>
           </Typography>
         );
       })}

--- a/src/components/pages/TeachersPage/Conversation.tsx
+++ b/src/components/pages/TeachersPage/Conversation.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource @emotion/react */
+import { useRef, useEffect } from 'react';
 
 import { Box, Typography } from '@mui/material';
 
@@ -7,6 +8,12 @@ import { filterWords } from '@utils/classrooms';
 
 export default function Conversation({ chat }) {
   const [student1, student2] = chat.studentPair;
+  const lastMessage = useRef(null);
+
+  useEffect(() => {
+    if (lastMessage.current)
+      lastMessage.current.scrollIntoView({ behavior: 'smooth' });
+  }, [chat.conversation]);
 
   return (
     <Box>
@@ -35,6 +42,8 @@ export default function Conversation({ chat }) {
           </Typography>
         );
       })}
+
+      <span ref={lastMessage} />
     </Box>
   );
 }

--- a/src/components/pages/TeachersPage/Conversation.tsx
+++ b/src/components/pages/TeachersPage/Conversation.tsx
@@ -4,15 +4,14 @@ import { useRef, useEffect } from 'react';
 import { Box, Typography } from '@mui/material';
 
 import conversationCSS from './Conversation.css';
-import { filterWords } from '@utils/classrooms';
+import { filterWords, scrollDown } from '@utils/classrooms';
 
 export default function Conversation({ chat }) {
   const [student1, student2] = chat.studentPair;
   const lastMessage = useRef(null);
 
   useEffect(() => {
-    if (lastMessage.current)
-      lastMessage.current.scrollIntoView({ behavior: 'smooth' });
+    scrollDown(lastMessage);
   }, [chat.conversation]);
 
   return (

--- a/src/components/pages/TeachersPage/index.tsx
+++ b/src/components/pages/TeachersPage/index.tsx
@@ -90,17 +90,16 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
       <Grid container spacing={2}>
         <Grid item xs={12} md={5}>
           <UnpairedStudentsList socket={socket} />
+          <PairedStudentsList
+            studentChats={studentChats}
+            setDisplayedChat={setDisplayedChat}
+          />
         </Grid>
 
         <Grid item xs={12} md={7}>
           {showDisplayedChat()}
         </Grid>
       </Grid>
-
-      <PairedStudentsList
-        studentChats={studentChats}
-        setDisplayedChat={setDisplayedChat}
-      />
     </main>
   );
 }

--- a/src/utils/classrooms.tsx
+++ b/src/utils/classrooms.tsx
@@ -41,6 +41,11 @@ export function filterWords(words) {
   }
 }
 
+export function scrollDown(lastMessage) {
+  if (lastMessage.current)
+    lastMessage.current.scrollIntoView({ behavior: 'smooth' });
+}
+
 export const sampleClassroomName = classrooms[0].classroomName;
 
 export interface ClassroomProps {


### PR DESCRIPTION
Moved the `PairedStudentList` in the Grid Item with `UnpairedStudentList` so that they will stay together when the chat on the right column grows.

Made some CSS changes to the ChatBox/Conversation Area to cap the height to 260px and overflow the chat area.  This will keep the user from needing to scroll the entire page to see the chat.

Created a style.css for next.js global styles and added scrollbar css to make scrollbars consistent across platforms (make windows scrollbars prettier)

Refactored the `ScrollDown` behavior to work with the changes made above.  Now just the chat area scrolls down when new messages are sent/received. Also moved the call to `ScrollDown` into a `useEffect` block to make sure that it happens after state is updated.  Without this the scroll down did not work reliably.

Closes #42