### PR TITLE
Refactor of peer left chat notification PR

### DIFF
--- a/src/components/pages/StudentsPage/SendMessages.tsx
+++ b/src/components/pages/StudentsPage/SendMessages.tsx
@@ -15,7 +15,7 @@ export default function SendMessages({ socket, chat, setChat }) {
 
   useEffect(() => {
     if (socket) {
-      socket.on('peer has left chat', () => {
+      socket.on('peer left chat', () => {
         setPeerHasLeft(true);
       });
 
@@ -37,7 +37,7 @@ export default function SendMessages({ socket, chat, setChat }) {
 
     return () => {
       if (socket) {
-        socket.off('peer has left chat');
+        socket.off('peer left chat');
         socket.off('peer is typing');
       }
     };

--- a/src/components/pages/TeachersPage/UnpairedStudentsList.tsx
+++ b/src/components/pages/TeachersPage/UnpairedStudentsList.tsx
@@ -35,31 +35,14 @@ export default function UnpairedStudentsList({ socket }) {
         setUnpairedStudents((unpaired) => [...unpaired, student]);
       });
 
-      socket.on('chat ended - two students', (chatEnded) => {
-        const student1 = chatEnded.student1;
-        const student2 = chatEnded.student2;
-        setUnpairedStudents((unpaired) => [...unpaired, student1, student2]);
+      socket.on('chat ended - two students', ({ student2 }) => {
+        setUnpairedStudents((unpaired) => [...unpaired, student2]);
       });
 
-      socket.on('student left', (student) => {
-        setUnpairedStudents((unpaired) => {
-          const studentIndex = unpaired.findIndex(
-            (s) => s.socketId === student.socketId,
-          );
-          if (studentIndex === -1) {
-            console.error(
-              'Student Not Found!',
-              unpaired,
-              student,
-              studentIndex,
-            );
-            return unpaired;
-          }
-          console.log(unpaired, studentIndex);
-          const newSet = [...unpaired];
-          newSet.splice(studentIndex, 1);
-          return newSet;
-        });
+      socket.on('unpaired student left', ({ socketId }) => {
+        setUnpairedStudents((students) =>
+          students.filter((student) => student.socketId !== socketId),
+        );
       });
     }
 

--- a/src/components/pages/TeachersPage/index.tsx
+++ b/src/components/pages/TeachersPage/index.tsx
@@ -49,23 +49,10 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
         ]);
       });
 
-      socket.on('chat ended - two students', (chatEnded) => {
-        const chatId = chatEnded.chatId;
-        const chatIndex = studentChats.findIndex(
-          (chat) => chat.chatId === chatEnded.chatId,
+      socket.on('chat ended - two students', ({ chatId }) => {
+        setStudentChats((chats) =>
+          chats.filter((chat) => chat.chatId !== chatId),
         );
-        const chats = [...studentChats];
-        chats.splice(chatIndex, 1);
-        setStudentChats(chats);
-
-        // This code can be turned back on after merging all PRs
-        // I made some mistakes with my branching strategy
-        // that left this bit hanging from PR# 44
-        // This code just resets the firstChatDisplayed flag
-        // if there are no chats left
-        // if (firstChatDisplayed && chats.length === 0) {
-        //   setFirstChatDisplayed(false);
-        // }
       });
 
       socket.on(
@@ -74,6 +61,7 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
           const chats = [...studentChats];
           const chat = chats.find((chat) => chat.chatId === chatId);
           if (!chat) return;
+
           const student =
             chat.studentPair[0].socketId === socketId ? 'student1' : 'student2';
           chat.conversation = [


### PR DESCRIPTION
Corresponding backend PR: https://github.com/mssiegel/frempco-server/pull/9

This PR refactors the frontend code from PR #47.

**Test plan:**
- When I closed an unpaired students browser, the student disappeared from the teachers page.
- When I closed a paired students browser, the other student was set as unpaired on the teachers page.
- When the teacher left early, the paired students were still able to chat.  (Previously, if there was no teacher this would crash the backend server)