### PR TITLE
Closes #51 Display Student Name (Alt: Move Modal)

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,31 +50,14 @@ export default function Home() {
   const router = useRouter();
   const apiUrl = `${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1`;
   const socket = useContext(SocketContext);
-  const [openStudentModal, setOpenStudentModal] = useState(false);
+
   const [openTeacherModal, setOpenTeacherModal] = useState(false);
-  const handleCloseStudentModal = () => setOpenStudentModal(false);
   const handleCloseTeacherModal = () => setOpenTeacherModal(false);
-  const classStudentInput = useRef<HTMLInputElement>(null);
-  const studentNameInput = useRef<HTMLInputElement>(null);
   const classTeacherInput = useRef<HTMLInputElement>(null);
   const passTeacherInput = useRef<HTMLInputElement>(null);
 
   async function visitStudentsPage() {
-    const classroom = classStudentInput.current.value;
-    const classroomObj = getClassroom(classroom);
-    if (!classroomObj) return window.alert(`Invalid classroom: ${classroom}`);
-    const getResponse = await fetch(`${apiUrl}/classrooms/${classroom}`);
-    const { isActive } = await getResponse.json();
-    if (!isActive)
-      return window.alert(
-        `Classroom not activated: ${classroom}\n Please wait for your teacher to activate your classroom and try again.`,
-      );
-    const student = studentNameInput.current.value;
-    if (student?.trim()) {
-      socket.emit('new student entered', { classroom, student });
-      // TODO: GET STUDENTS NAME TO SHOW ON STUDENT PAGE
-      router.push(`/student/classroom/${classroom}`);
-    }
+    router.push(`/student/classroom/setupClassroom`);
   }
 
   function visitTeachersPage() {
@@ -119,7 +102,7 @@ export default function Home() {
                 variant='contained'
                 size='large'
                 startIcon={<LightbulbIcon />}
-                onClick={() => setOpenStudentModal(true)}
+                onClick={visitStudentsPage}
               >
                 Students page
               </Button>
@@ -144,24 +127,6 @@ export default function Home() {
             </Box>
           </Grid>
         </Grid>
-
-        <BasicModal
-          open={openStudentModal}
-          handleClose={handleCloseStudentModal}
-        >
-          <Typography variant='h5'>Hello student</Typography>
-
-          <ModalTextField
-            label='Classroom'
-            refObject={classStudentInput}
-            autoFocus={true}
-          />
-          <ModalTextField label='Your Name' refObject={studentNameInput} />
-
-          <Button variant='contained' size='large' onClick={visitStudentsPage}>
-            Visit Student&apos;s Room
-          </Button>
-        </BasicModal>
 
         <BasicModal
           open={openTeacherModal}

--- a/pages/student/classroom/[classroomName].tsx
+++ b/pages/student/classroom/[classroomName].tsx
@@ -1,12 +1,18 @@
 import Head from 'next/head';
-
+import { Button, Typography } from '@mui/material';
 import { getAllClassroomNames, ClassroomProps } from '@utils/classrooms';
 import Layout from '@components/shared/Layout';
 import StudentsPage from '@components/pages/StudentsPage';
+import BasicModal from '@components/shared/Modal';
+import ModalTextField from '@components/shared/ModalTextField';
+import { useRef, useState, useContext, useEffect } from 'react';
+import { getClassroom } from '@utils/classrooms';
+import { SocketContext } from '@contexts/SocketContext';
+import { useRouter } from 'next/router';
 
 export async function getStaticPaths() {
   const paths = getAllClassroomNames();
-
+  paths.push({ params: { classroomName: 'setupClassroom' } });
   return {
     paths,
     fallback: false,
@@ -22,6 +28,46 @@ export async function getStaticProps({ params }) {
 }
 
 export default function StudentPage({ classroomName }: ClassroomProps) {
+  const apiUrl = `${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1`;
+  const router = useRouter();
+  const classStudentInput = useRef<HTMLInputElement>(null);
+  const studentNameInput = useRef<HTMLInputElement>(null);
+  const [studentName, setStudentName] = useState('');
+  const [openStudentModal, setOpenStudentModal] = useState(false);
+  const handleCloseStudentModal = () => setOpenStudentModal(false);
+  const socket = useContext(SocketContext);
+
+  useEffect(() => {
+    if (!studentName && classroomName === 'setupClassroom') {
+      setOpenStudentModal(true);
+    }
+    if (studentName && classroomName !== 'setupClassroom') {
+      socket.emit('new student entered', {
+        classroom: classroomName,
+        student: studentName,
+      });
+      setOpenStudentModal(false);
+    }
+  }, [classroomName, studentName]);
+
+  async function visitStudentsPage() {
+    const classroom = classStudentInput.current.value;
+    const classroomObj = getClassroom(classroom);
+    if (!classroomObj) return window.alert(`Invalid classroom: ${classroom}`);
+    const getResponse = await fetch(`${apiUrl}/classrooms/${classroom}`);
+    const { isActive } = await getResponse.json();
+    if (!isActive)
+      return window.alert(
+        `Classroom not activated: ${classroom}\n Please wait for your teacher to activate your classroom and try again.`,
+      );
+    const student = studentNameInput.current.value;
+    if (student?.trim()) {
+      router.push(`/student/classroom/${classroom}`);
+      setOpenStudentModal(false);
+      setStudentName(student);
+    }
+  }
+
   return (
     <Layout>
       <Head>
@@ -29,7 +75,24 @@ export default function StudentPage({ classroomName }: ClassroomProps) {
         <link rel='icon' href='/favicon.ico' />
       </Head>
 
-      <StudentsPage classroomName={classroomName} />
+      <BasicModal open={openStudentModal}>
+        <Typography variant='h5'>Hello student</Typography>
+
+        <ModalTextField
+          label='Classroom'
+          refObject={classStudentInput}
+          autoFocus={true}
+        />
+        <ModalTextField label='Your Name' refObject={studentNameInput} />
+
+        <Button variant='contained' size='large' onClick={visitStudentsPage}>
+          Visit Student&apos;s Room
+        </Button>
+      </BasicModal>
+
+      {!openStudentModal && classroomName !== 'setupClassroom' && (
+        <StudentsPage classroomName={classroomName} student={studentName} />
+      )}
     </Layout>
   );
 }

--- a/src/components/pages/StudentsPage/index.tsx
+++ b/src/components/pages/StudentsPage/index.tsx
@@ -7,7 +7,10 @@ import Chatbox from './Chatbox';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 
-export default function StudentsPage({ classroomName }: ClassroomProps) {
+export default function StudentsPage({
+  classroomName,
+  student,
+}: ClassroomProps) {
   const socket = useContext(SocketContext);
   console.log('Student socketId:', socket?.id ?? 'No socket found');
 
@@ -61,7 +64,7 @@ export default function StudentsPage({ classroomName }: ClassroomProps) {
   return (
     <main>
       <Typography variant='h4' sx={{ color: 'white', mb: 4 }}>
-        Hello student! Welcome to your classroom: {classroomName}
+        Hello {student}! Welcome to your classroom: {classroomName}
       </Typography>
       {chatInSession && (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>

--- a/src/utils/classrooms.tsx
+++ b/src/utils/classrooms.tsx
@@ -50,6 +50,7 @@ export const sampleClassroomName = classrooms[0].classroomName;
 
 export interface ClassroomProps {
   classroomName: string;
+  student: string;
 }
 
 export interface Student {

--- a/src/utils/classrooms.tsx
+++ b/src/utils/classrooms.tsx
@@ -50,7 +50,7 @@ export const sampleClassroomName = classrooms[0].classroomName;
 
 export interface ClassroomProps {
   classroomName: string;
-  student: string;
+  student?: string;
 }
 
 export interface Student {


### PR DESCRIPTION
Closes #51

After reviewing our current SocketContext, I realized there was no quick or easy way to use this context to store global app info, so I went ahead with the easy way and moved the modal into the student classroom page.

I was able to accomplish this by adding a `setupClassroom` path and using `useEffect` to check for this and whether or not the student name had been set yet.

The rest of the Modal and logic remained much the same.

I've made these changes live on my temp server: [http://208.87.134.100:3000](http://208.87.134.100:3000)