### PR TITLE
Made home link dev only

### DIFF
--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -17,9 +17,17 @@ export default function Layout({ children }: LayoutProps) {
 function Navbar() {
   return (
     <Typography variant='h4' sx={{ ml: 10, pt: 1, pb: 2 }}>
-      <Link href='/' underline='hover' color='white'>
-        Home
-      </Link>
+      {process.env.NEXT_PUBLIC_NODE_ENV === 'development' && (
+        <>
+          <Typography variant='h5' sx={{ color: 'gray' }}>
+            This link shortcut only appears in the development environment:
+            {/* For an explanation: see https://github.com/mssiegel/frempco-client/issues/53 */}
+          </Typography>
+          <Link href='/' underline='hover' color='white'>
+            Home
+          </Link>
+        </>
+      )}
     </Typography>
   );
 }


### PR DESCRIPTION
Temporarily solves Issue #53 by making the Home shortcut link only appear on the development environment.
This is a temp fix while comment in PR #55 is resolved.
This fix needs to be merged by Wednesday at 1pm EST as that is when a high school teacher will use Frempco.

![image](https://user-images.githubusercontent.com/29524485/156294646-c85c632d-f625-4453-82ee-81d7f92888b5.png)