### PR TITLE
Closes #51 Display Student Name (Alt: useContext)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import { CacheProvider, EmotionCache } from '@emotion/react';
 import theme from '@theme/muiTheme';
 import { createEmotionCache } from '@config/emotion';
 import { SocketProvider } from 'src/contexts/SocketContext';
+import { UserProvider } from 'src/contexts/UserContext';
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
@@ -29,7 +30,9 @@ export default function MyApp(props: MyAppProps) {
         {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
         <CssBaseline />
         <SocketProvider>
-          <Component {...pageProps} />
+          <UserProvider>
+            <Component {...pageProps} />
+          </UserProvider>
         </SocketProvider>
       </ThemeProvider>
     </CacheProvider>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,7 @@ import Link from '@components/shared/Link';
 import Layout from '@components/shared/Layout';
 import { getClassroom, sampleClassroomName } from '@utils/classrooms';
 import { SocketContext } from '@contexts/SocketContext';
+import { UserContext } from '@contexts/UserContext';
 import Chatbox from '@components/pages/TeachersPage/Chatbox';
 import BasicModal from '@components/shared/Modal';
 import ModalTextField from '@components/shared/ModalTextField';
@@ -50,6 +51,7 @@ export default function Home() {
   const router = useRouter();
   const apiUrl = `${process.env.NEXT_PUBLIC_SERVER_URL}/api/v1`;
   const socket = useContext(SocketContext);
+  const { setUserInfo } = useContext(UserContext);
   const [openStudentModal, setOpenStudentModal] = useState(false);
   const [openTeacherModal, setOpenTeacherModal] = useState(false);
   const handleCloseStudentModal = () => setOpenStudentModal(false);
@@ -72,6 +74,7 @@ export default function Home() {
     const student = studentNameInput.current.value;
     if (student?.trim()) {
       socket.emit('new student entered', { classroom, student });
+      setUserInfo({ studentName: student });
       // TODO: GET STUDENTS NAME TO SHOW ON STUDENT PAGE
       router.push(`/student/classroom/${classroom}`);
     }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -74,8 +74,7 @@ export default function Home() {
     const student = studentNameInput.current.value;
     if (student?.trim()) {
       socket.emit('new student entered', { classroom, student });
-      setUserInfo({ studentName: student });
-      // TODO: GET STUDENTS NAME TO SHOW ON STUDENT PAGE
+      setUserInfo({ name: student });
       router.push(`/student/classroom/${classroom}`);
     }
   }

--- a/src/components/pages/StudentsPage/index.tsx
+++ b/src/components/pages/StudentsPage/index.tsx
@@ -11,7 +11,7 @@ import Link from 'next/link';
 export default function StudentsPage({ classroomName }: ClassroomProps) {
   const socket = useContext(SocketContext);
   const { userInfo } = useContext(UserContext);
-  const studentName = userInfo.studentName;
+  const { name } = userInfo;
   console.log('Student socketId:', socket?.id ?? 'No socket found');
 
   const [chatInSession, setChatInSession] = useState(false);
@@ -64,7 +64,7 @@ export default function StudentsPage({ classroomName }: ClassroomProps) {
   return (
     <main>
       <Typography variant='h4' sx={{ color: 'white', mb: 4 }}>
-        Hello {studentName}! Welcome to your classroom: {classroomName}
+        Hello {name}! Welcome to your classroom: {classroomName}
       </Typography>
       {chatInSession && (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>

--- a/src/components/pages/StudentsPage/index.tsx
+++ b/src/components/pages/StudentsPage/index.tsx
@@ -3,12 +3,15 @@ import { useContext, useEffect, useState } from 'react';
 
 import { ClassroomProps, currentTime } from '@utils/classrooms';
 import { SocketContext } from '@contexts/SocketContext';
+import { UserContext } from '@contexts/UserContext';
 import Chatbox from './Chatbox';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 
 export default function StudentsPage({ classroomName }: ClassroomProps) {
   const socket = useContext(SocketContext);
+  const { userInfo } = useContext(UserContext);
+  const studentName = userInfo.studentName;
   console.log('Student socketId:', socket?.id ?? 'No socket found');
 
   const [chatInSession, setChatInSession] = useState(false);
@@ -61,7 +64,7 @@ export default function StudentsPage({ classroomName }: ClassroomProps) {
   return (
     <main>
       <Typography variant='h4' sx={{ color: 'white', mb: 4 }}>
-        Hello student! Welcome to your classroom: {classroomName}
+        Hello {studentName}! Welcome to your classroom: {classroomName}
       </Typography>
       {chatInSession && (
         <Box sx={{ display: 'flex', justifyContent: 'center' }}>

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -5,18 +5,18 @@ interface ProviderProps {
 }
 
 type UserCtxType = {
-  userInfo: { studentName: string };
-  setUserInfo: Dispatch<SetStateAction<{ studentName: string }>>;
+  userInfo: { name: string };
+  setUserInfo: Dispatch<SetStateAction<{ name: string }>>;
 };
 
 const UserContext = createContext<UserCtxType>({
-  userInfo: { studentName: '' },
+  userInfo: { name: '' },
   setUserInfo: () => {},
 });
 
 function UserProvider({ children }: ProviderProps) {
   const [userInfo, setUserInfo] = useState({
-    studentName: '',
+    name: '',
   });
 
   const userState = { userInfo, setUserInfo };

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,0 +1,29 @@
+import { createContext, Dispatch, SetStateAction, useState } from 'react';
+
+interface ProviderProps {
+  children: React.ReactNode;
+}
+
+type UserCtxType = {
+  userInfo: { studentName: string };
+  setUserInfo: Dispatch<SetStateAction<{ studentName: string }>>;
+};
+
+const UserContext = createContext<UserCtxType>({
+  userInfo: { studentName: '' },
+  setUserInfo: () => {},
+});
+
+function UserProvider({ children }: ProviderProps) {
+  const [userInfo, setUserInfo] = useState({
+    studentName: '',
+  });
+
+  const userState = { userInfo, setUserInfo };
+
+  return (
+    <UserContext.Provider value={userState}>{children}</UserContext.Provider>
+  );
+}
+
+export { UserContext, UserProvider };


### PR DESCRIPTION
Closes #51 Display Student Name

This is an alternative to PR #56 

Instead of moving the modal into the students classroom page, a `UserContext` was created to store `UserInfo`.  In This Case just the Student Name, but could be used in the future to store other user details.
