### PR TITLE
Issue 61 bug fix when student leaves

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,7 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "react-hooks/rules-of-hooks": "error", // Checks rules of Hooks
+    "react-hooks/exhaustive-deps": "warn" // Checks effect dependencies
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "babel-plugin-import": "^1.13.3",
         "eslint": "8.1.0",
         "eslint-config-next": "11.1.2",
+        "eslint-plugin-react-hooks": "^4.3.0",
         "typescript": "^4.4.4"
       }
     },
@@ -2697,15 +2698,15 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true,
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -7860,9 +7861,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-plugin-import": "^1.13.3",
     "eslint": "8.1.0",
     "eslint-config-next": "11.1.2",
+    "eslint-plugin-react-hooks": "^4.3.0",
     "typescript": "^4.4.4"
   }
 }

--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -22,7 +22,7 @@ export default function Conversation({ socket, chat, setChat }) {
     return () => {
       if (socket) socket.off('chat message');
     };
-  }, []);
+  }, [setChat, socket]);
 
   useEffect(() => {
     scrollDown(lastMessage);

--- a/src/components/pages/StudentsPage/SendMessages.tsx
+++ b/src/components/pages/StudentsPage/SendMessages.tsx
@@ -38,10 +38,12 @@ export default function SendMessages({ socket, chat, setChat }) {
     return () => {
       if (socket) {
         socket.off('peer left chat');
+        socket.off('chat start');
+        socket.off('chat message');
         socket.off('peer is typing');
       }
     };
-  });
+  }, [socket]);
 
   function sendMessage(e) {
     e.preventDefault();

--- a/src/components/pages/StudentsPage/index.tsx
+++ b/src/components/pages/StudentsPage/index.tsx
@@ -53,7 +53,7 @@ export default function StudentsPage({ classroomName }: ClassroomProps) {
         router.events.off('routeChangeStart', handleRouteChange);
       }
     };
-  });
+  }, [router.events, socket]);
 
   return (
     <main>

--- a/src/components/pages/TeachersPage/UnpairedStudentsList.tsx
+++ b/src/components/pages/TeachersPage/UnpairedStudentsList.tsx
@@ -8,7 +8,6 @@ import {
   List,
   ListItemText,
   ListSubheader,
-  Typography,
   TextField,
 } from '@mui/material';
 import { Chat as ChatIcon, PersonOutline } from '@mui/icons-material';
@@ -66,10 +65,10 @@ export default function UnpairedStudentsList({ socket }) {
       if (socket) {
         socket.off('new student joined');
         socket.off('chat ended - two students');
-        socket.off('student left');
+        socket.off('unpaired student left');
       }
     };
-  });
+  }, [socket]);
 
   function pairStudents() {
     if (unpairedStudents.length < 2)

--- a/src/components/pages/TeachersPage/UnpairedStudentsList.tsx
+++ b/src/components/pages/TeachersPage/UnpairedStudentsList.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material';
 import { Chat as ChatIcon, PersonOutline } from '@mui/icons-material';
 
-import { getRandom, swap, Student } from '@utils/classrooms';
+import { getRandom, swap } from '@utils/classrooms';
 import unpairedStudentsCSS from './UnpairedStudentsList.css';
 import BasicModal from '@components/shared/Modal';
 
@@ -25,8 +25,11 @@ const CHARACTERS = [
   'Party planner',
 ];
 
-export default function UnpairedStudentsList({ socket }) {
-  const [unpairedStudents, setUnpairedStudents] = useState<Student[]>([]);
+export default function UnpairedStudentsList({
+  socket,
+  unpairedStudents,
+  setUnpairedStudents,
+}) {
   const [characters, setCharacters] = useState(CHARACTERS);
   const [openCharacterModal, setOpenCharacterModal] = useState(false);
   const handleCloseCharacterModal = () => setOpenCharacterModal(false);
@@ -50,10 +53,6 @@ export default function UnpairedStudentsList({ socket }) {
         setUnpairedStudents((unpaired) => [...unpaired, student]);
       });
 
-      socket.on('chat ended - two students', ({ student2 }) => {
-        setUnpairedStudents((unpaired) => [...unpaired, student2]);
-      });
-
       socket.on('unpaired student left', ({ socketId }) => {
         setUnpairedStudents((students) =>
           students.filter((student) => student.socketId !== socketId),
@@ -64,11 +63,10 @@ export default function UnpairedStudentsList({ socket }) {
     return () => {
       if (socket) {
         socket.off('new student joined');
-        socket.off('chat ended - two students');
         socket.off('unpaired student left');
       }
     };
-  }, [socket]);
+  }, [setUnpairedStudents, socket]);
 
   function pairStudents() {
     if (unpairedStudents.length < 2)

--- a/src/components/pages/TeachersPage/index.tsx
+++ b/src/components/pages/TeachersPage/index.tsx
@@ -26,6 +26,7 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
   const socket = useContext(SocketContext);
   console.log('Teacher socketId:', socket?.id ?? 'No socket found');
 
+  const [unpairedStudents, setUnpairedStudents] = useState<Student[]>([]);
   const [displayedChat, setDisplayedChat] = useState('');
   const [studentChats, setStudentChats] = useState<StudentChat[]>([
     // {
@@ -57,10 +58,14 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
         ]);
       });
 
-      socket.on('chat ended - two students', ({ chatId }) => {
+      socket.on('chat ended - two students', ({ chatId, student2 }) => {
+        // remove the chat
         setStudentChats((chats) =>
           chats.filter((chat) => chat.chatId !== chatId),
         );
+
+        // add the student who remains back into unpaired student list
+        setUnpairedStudents((unpaired) => [...unpaired, student2]);
       });
 
       socket.on(
@@ -108,7 +113,11 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
 
       <Grid container spacing={2}>
         <Grid item xs={12} md={5}>
-          <UnpairedStudentsList socket={socket} />
+          <UnpairedStudentsList
+            socket={socket}
+            unpairedStudents={unpairedStudents}
+            setUnpairedStudents={setUnpairedStudents}
+          />
           <PairedStudentsList
             studentChats={studentChats}
             setDisplayedChat={setDisplayedChat}

--- a/src/components/pages/TeachersPage/index.tsx
+++ b/src/components/pages/TeachersPage/index.tsx
@@ -89,7 +89,7 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
         router.events.off('routeChangeStart', handleRouteChange);
       }
     };
-  });
+  }, [router.events, socket, studentChats]);
 
   function showDisplayedChat() {
     const chat = studentChats.find((chat) => chat.chatId === displayedChat);


### PR DESCRIPTION
Closes: #61 

This PR:

- Addes the [recommended ESLint plugin for React Hooks](https://reactjs.org/docs/hooks-rules.html#eslint-plugin). Updated all useEffect hooks to fix the new Linter warnings that appeared
- Combines the two `'chat-ended - two students'` event listeners into one
- A few minor fixes, such as `socket.off` events that we were missing

**Test Plan:** 
I followed all steps to reproduce in Issue #61 and the bug was fixed!

**Learnings:**
Having two react components on the same page listen for the same socket event **will mess with React's internals**.  To be extra safe, I propose we **never** listen for the same socket event twice on the client side. Even when the event listener is on different pages. 