### PR TITLE
closes #91 copy chat

### DIFF
--- a/src/components/pages/StudentsPage/Chatbox.tsx
+++ b/src/components/pages/StudentsPage/Chatbox.tsx
@@ -1,14 +1,44 @@
 /** @jsxImportSource @emotion/react */
 
-import { Box } from '@mui/material';
+import { Box, Fab } from '@mui/material';
+import { ContentCopy as ContentCopyIcon } from '@mui/icons-material';
 
 import chatboxCSS from './Chatbox.css';
 import Conversation from './Conversation';
 import SendMessages from './SendMessages';
 
 export default function Chatbox({ socket, chat, setChat }) {
+  const copyToClipboard = (elementId) => {
+    let temp = document.createElement('div');
+    temp.setAttribute('contentEditable', 'true');
+    temp.innerHTML = document.getElementById(elementId).innerHTML;
+    temp.setAttribute(
+      'onfocus',
+      "document.execCommand('selectAll',false,null)",
+    );
+    document.body.appendChild(temp);
+    temp.focus();
+    document.execCommand('copy');
+    document.body.removeChild(temp);
+    alert('Conversation copied to clipboard');
+  };
+
   return (
     <Box css={chatboxCSS.chatboxContainer}>
+      <Fab
+        variant='extended'
+        size='small'
+        color='primary'
+        style={{
+          marginBottom: '10px',
+          background: '#940000',
+          textTransform: 'none',
+        }}
+        onClick={() => copyToClipboard('conversation')}
+      >
+        Copy chat
+        <ContentCopyIcon />
+      </Fab>
       <Box css={chatboxCSS.chatboxTop}>
         <Conversation socket={socket} chat={chat} setChat={setChat} />
       </Box>

--- a/src/components/pages/StudentsPage/Conversation.tsx
+++ b/src/components/pages/StudentsPage/Conversation.tsx
@@ -29,7 +29,7 @@ export default function Conversation({ socket, chat, setChat }) {
   }, [chat.conversation]);
 
   return (
-    <Box>
+    <Box id='conversation'>
       <Box css={conversationCSS.introText}>
         <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
           <span>


### PR DESCRIPTION
Closes #91 

Added a copy chat button to copy the conversation to the clipboard:
![image](https://user-images.githubusercontent.com/47090434/159202288-3979cf83-4566-4ddc-90dd-029d9c2d39be.png)

With alert:
![image](https://user-images.githubusercontent.com/47090434/159202403-4e9ce024-e181-410f-a7f8-7f77cb43239e.png)

Format of the text when pasted in Gmail:
![image](https://user-images.githubusercontent.com/47090434/159202498-b044bee5-e1b5-4f38-b870-9691f1f71464.png)


- Thoughts on the styling or location of the button?
- Do we need the alert? To be consistent I matched the "invalid classroom" alert. I could switch this over to a styled toast notification.
- So far I've tested this works on Chrome, Edge, and Samsung Internet. Firefox browser does not copy with formatting, just black and white. Unfortunately, I don't have a device to test Safari browser, would be good to get your guys feedback if you're able to test. 