### PR TITLE
Allow capitalized classroom names to work

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -63,7 +63,7 @@ export default function Home() {
   const passTeacherInput = useRef<HTMLInputElement>(null);
 
   async function visitStudentsPage() {
-    const classroom = classStudentInput.current.value?.trim();
+    const classroom = classStudentInput.current.value?.trim().toLowerCase();
     const student = studentNameInput.current.value?.trim();
     await visitStudentsPageHelper(classroom, student);
   }
@@ -99,7 +99,7 @@ export default function Home() {
   );
 
   function visitTeachersPage() {
-    const classroom = classTeacherInput.current.value?.trim();
+    const classroom = classTeacherInput.current.value?.trim().toLowerCase();
     const classroomObj = getClassroom(classroom);
     if (!classroomObj) return window.alert(`Invalid classroom: ${classroom}`);
 


### PR DESCRIPTION
This code change is so small, I just made a PR and didn't bother creating an issue.

My Android phone capitalizes the first letter of any text I enter into the classroom name input. This PR converts the inputted classroom name to lowercase. This allows any combination of uppercase or lowercase to work. This makes it faster and easier for students to enter the classroom name on mobile phones.