### PR TITLE
Refactor: extract dev link shortcuts from homepage into its own compo…

### DIFF
--- a/src/components/pages/HomePage/DevLinkShortcuts.tsx
+++ b/src/components/pages/HomePage/DevLinkShortcuts.tsx
@@ -1,0 +1,32 @@
+/** @jsxImportSource @emotion/react */
+
+import { Typography } from '@mui/material';
+
+import { testClassroomName } from '@utils/classrooms';
+import Link from '@components/shared/Link';
+
+export default function DevLinkShortcuts({ visitStudentsPageHelper }) {
+  async function testVisitStudentsPage() {
+    const classroom = testClassroomName;
+    const student = `Student ${Math.trunc(Math.random() * 10000).toString()}`;
+    await visitStudentsPageHelper(classroom, student);
+  }
+
+  return (
+    <>
+      <Typography variant='h5' sx={{ m: 3, mt: 10, color: 'gray' }}>
+        These link shortcuts only appear in the development environment:
+      </Typography>
+      <Typography variant='h5' sx={{ m: 3 }}>
+        <Link href={`/teacher/classroom/${testClassroomName}`}>
+          Visit Teachers admin page
+        </Link>
+      </Typography>
+      <Typography variant='h5' sx={{ m: 3 }}>
+        <Link href='#' onClick={testVisitStudentsPage}>
+          Visit Students classroom page
+        </Link>
+      </Typography>
+    </>
+  );
+}

--- a/src/components/pages/HomePage/index.tsx
+++ b/src/components/pages/HomePage/index.tsx
@@ -7,13 +7,13 @@ import { useContext, useState, useRef, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { throttle } from 'lodash-es';
 
-import Link from '@components/shared/Link';
-import { getClassroom, sampleClassroomName } from '@utils/classrooms';
+import { getClassroom } from '@utils/classrooms';
 import { SocketContext } from '@contexts/SocketContext';
 import { UserContext } from '@contexts/UserContext';
 import Chatbox from '@components/pages/TeachersPage/Chatbox';
 import BasicModal from '@components/shared/Modal';
 import ModalTextField from '@components/shared/ModalTextField';
+import DevLinkShortcuts from './DevLinkShortcuts';
 
 const exampleChat = {
   chatId: 'homepage sample chat',
@@ -66,14 +66,6 @@ export default function HomePage() {
     await visitStudentsPageHelper(classroom, student);
   }
 
-  // for dev link shortcut
-  async function testVisitStudentsPage() {
-    // grabs test classroom name
-    const classroom = sampleClassroomName;
-    const student = `Student ${Math.trunc(Math.random() * 10000).toString()}`;
-    await visitStudentsPageHelper(classroom, student);
-  }
-
   async function visitStudentsPageHelper(classroom: string, student: string) {
     const classroomObj = getClassroom(classroom);
     if (!classroomObj) return window.alert(`Invalid classroom: ${classroom}`);
@@ -121,7 +113,7 @@ export default function HomePage() {
         <Grid item xs={12} md={4}>
           <Box sx={{ m: 5 }}>
             <Typography variant='h3' sx={{ color: 'white', mb: 1 }}>
-              For Students:
+              Students:
             </Typography>
             <Button
               variant='contained'
@@ -133,7 +125,7 @@ export default function HomePage() {
             </Button>
 
             <Typography variant='h3' sx={{ color: 'white', mb: 1, mt: 8 }}>
-              For Teachers:
+              Teachers:
             </Typography>
             <Button
               variant='contained'
@@ -192,21 +184,7 @@ export default function HomePage() {
       </BasicModal>
 
       {process.env.NEXT_PUBLIC_NODE_ENV === 'development' && (
-        <>
-          <Typography variant='h5' sx={{ m: 3, mt: 10, color: 'gray' }}>
-            These link shortcuts only appear in the development environment:
-          </Typography>
-          <Typography variant='h5' sx={{ m: 3 }}>
-            <Link href={`/teacher/classroom/${sampleClassroomName}`}>
-              Visit Teachers admin page
-            </Link>
-          </Typography>
-          <Typography variant='h5' sx={{ m: 3 }}>
-            <Link href='#' onClick={testVisitStudentsPage}>
-              Visit Students classroom page
-            </Link>
-          </Typography>
-        </>
+        <DevLinkShortcuts visitStudentsPageHelper={visitStudentsPageHelper} />
       )}
     </main>
   );

--- a/src/utils/classrooms.tsx
+++ b/src/utils/classrooms.tsx
@@ -46,7 +46,7 @@ export function scrollDown(refObject) {
     refObject.current.scrollIntoView({ behavior: 'smooth' });
 }
 
-export const sampleClassroomName = classrooms[0].classroomName;
+export const testClassroomName = classrooms[0].classroomName;
 
 export interface ClassroomProps {
   classroomName: string;


### PR DESCRIPTION
Closes #103 

Refactors the homepage's dev link shortcuts into its own component. 

**Test plan:** I visited the homepage and clicked the dev link shortcuts for both a teacher and several students. It worked correctly. 