### PR TITLE
centers the chatbox on mobile; keeps everything else the same

### DIFF
--- a/src/components/pages/StudentsPage/Chatbox.css.tsx
+++ b/src/components/pages/StudentsPage/Chatbox.css.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
 
 const chatboxContainer = css`
-  width: 98%;
+  margin-left: -13px;
+  margin-right: -13px;
   max-width: 500px;
 `;
 

--- a/src/components/pages/StudentsPage/Chatbox.css.tsx
+++ b/src/components/pages/StudentsPage/Chatbox.css.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/react';
 
 const chatboxContainer = css`
+  max-width: 500px;
+  /* widens the student chatbox to more easily type messages on mobile */
   margin-left: -13px;
   margin-right: -13px;
-  max-width: 500px;
 `;
 
 const chatboxTop = css`

--- a/src/components/pages/TeachersPage/Chatbox.css.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.css.tsx
@@ -1,7 +1,8 @@
 import { css } from '@emotion/react';
 
 const chatboxContainer = css`
-  width: 98%;
+  margin-left: -13px;
+  margin-right: -13px;
   max-width: 500px;
 `;
 

--- a/src/components/pages/TeachersPage/Chatbox.css.tsx
+++ b/src/components/pages/TeachersPage/Chatbox.css.tsx
@@ -1,8 +1,6 @@
 import { css } from '@emotion/react';
 
 const chatboxContainer = css`
-  margin-left: -13px;
-  margin-right: -13px;
   max-width: 500px;
 `;
 

--- a/src/components/shared/Layout.tsx
+++ b/src/components/shared/Layout.tsx
@@ -7,7 +7,7 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   return (
-    <Box sx={{ background: '#87002a', minHeight: '100vh', pl: 2 }}>
+    <Box sx={{ background: '#87002a', minHeight: '100vh', px: 2 }}>
       <Navbar />
       {children}
     </Box>


### PR DESCRIPTION
Closes #112 

Keeps the padding in Layout so that everything outside of the chatbox has some empty space from the edge of the browser.  But uses negative margin to remove that extra space for the chatboxes.

Students chatbox Mobile view: 
![image](https://user-images.githubusercontent.com/29524485/161463390-f349956a-5f70-4ca7-835b-dc669ba127f0.png)

Hompage Mobile view: 
![image](https://user-images.githubusercontent.com/29524485/161463562-9627409e-9cdf-4e35-b78b-e6afa8fb2f2d.png)

Homepage Desktop view: 
![image](https://user-images.githubusercontent.com/29524485/161463657-36be702b-75d3-4059-9ea4-e91f8bc852a9.png)

Students Page Desktop view:
![image](https://user-images.githubusercontent.com/29524485/161463711-b94d8110-dca1-400b-909d-4a0bbf4df742.png)
