### PR TITLE
Limits a student's name to 25 characters

### DIFF
--- a/src/components/pages/HomePage/index.tsx
+++ b/src/components/pages/HomePage/index.tsx
@@ -156,7 +156,11 @@ export default function HomePage() {
           refObject={classStudentInput}
           autoFocus={true}
         />
-        <ModalTextField label='Your Name' refObject={studentNameInput} />
+        <ModalTextField
+          label='Your Name'
+          refObject={studentNameInput}
+          maxLength={25}
+        />
 
         <Button
           variant='contained'

--- a/src/components/shared/ModalTextField.tsx
+++ b/src/components/shared/ModalTextField.tsx
@@ -5,6 +5,7 @@ export default function ModalTextField({
   refObject,
   autoFocus = false,
   type = 'input',
+  maxLength = 100,
 }) {
   return (
     <TextField
@@ -16,6 +17,7 @@ export default function ModalTextField({
       autoComplete='off'
       inputRef={refObject}
       autoFocus={autoFocus}
+      inputProps={{ maxLength }}
     />
   );
 }


### PR DESCRIPTION
Closes #118 

Added max length to student name text field

**Test plan:** I could no longer add more than 25 characters to my name as a student