### PR TITLE
Refactor: unpair student chat function

### DIFF
--- a/src/components/pages/TeachersPage/PairedStudentListItem.tsx
+++ b/src/components/pages/TeachersPage/PairedStudentListItem.tsx
@@ -1,15 +1,26 @@
 /** @jsxImportSource @emotion/react */
 
+import { useContext } from 'react';
 import { Divider, Button, Box } from '@mui/material';
 
+import { SocketContext } from '@contexts/SocketContext';
 import conversationCSS from './Conversation.css';
 
 export default function PairedStudentListItem({
   studentChats,
   displayedChat,
   setDisplayedChat,
-  unpair,
 }) {
+  const socket = useContext(SocketContext);
+
+  function unpair(chatId, student1, student2) {
+    const unpairConfirmed = confirm(
+      `Are you sure you want to unpair ${student1.realName} & ${student2.realName}?`,
+    );
+    unpairConfirmed &&
+      socket.emit('unpair student chat', { chatId, student1, student2 });
+  }
+
   return (
     <>
       {studentChats.map(({ chatId, studentPair: [student1, student2] }) => {

--- a/src/components/pages/TeachersPage/PairedStudentsList.tsx
+++ b/src/components/pages/TeachersPage/PairedStudentsList.tsx
@@ -5,7 +5,6 @@ export default function PairedStudentsList({
   studentChats,
   setDisplayedChat,
   displayedChat,
-  unpair,
 }) {
   return (
     <Box
@@ -22,7 +21,6 @@ export default function PairedStudentsList({
         studentChats={studentChats}
         setDisplayedChat={setDisplayedChat}
         displayedChat={displayedChat}
-        unpair={unpair}
       />
     </Box>
   );

--- a/src/components/pages/TeachersPage/index.tsx
+++ b/src/components/pages/TeachersPage/index.tsx
@@ -43,14 +43,6 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
     // },
   ]);
 
-  const unpair = (chatId, student1, student2) => {
-    const unpairConfirmed = confirm(
-      `Are you sure you want to unpair ${student1.realName} & ${student2.realName} ?`,
-    );
-    unpairConfirmed &&
-      socket.emit('unpair student chat', { chatId, student1, student2 });
-  };
-
   useEffect(() => {
     if (socket) {
       socket.on('chat started - two students', ({ chatId, studentPair }) => {
@@ -157,7 +149,6 @@ export default function TeachersPage({ classroomName }: ClassroomProps) {
             studentChats={studentChats}
             setDisplayedChat={setDisplayedChat}
             displayedChat={displayedChat}
-            unpair={unpair}
           />
         </Grid>
 


### PR DESCRIPTION
Removed the need to pass down through props by moving `unpair()` directly into the component which uses it.

**Test plan:** I unpaired a chat between two students. The button worked as expected. 